### PR TITLE
token manager & access token refresh

### DIFF
--- a/jut/api/accounts.py
+++ b/jut/api/accounts.py
@@ -6,7 +6,7 @@ import requests
 import json
 
 from jut import defaults
-from jut.api import auth, environment
+from jut.api import environment
 from jut.exceptions import JutException
 
 
@@ -14,13 +14,13 @@ def create_user(name,
                 username,
                 email,
                 password,
-                access_token=None,
+                token_manager=None,
                 app_url=defaults.APP_URL):
     """
     create a new user with the specified name, username email and password
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
     url = "%s/api/v1/accounts" % auth_url
 
@@ -43,7 +43,7 @@ def create_user(name,
 
 
 def delete_user(username,
-                access_token=None,
+                token_manager=None,
                 app_url=defaults.APP_URL):
     """
     delete a user by its account_id and with the access_token from that same
@@ -51,10 +51,10 @@ def delete_user(username,
 
     """
     account_id = get_account_id(username,
-                                access_token=access_token,
+                                token_manager=token_manager,
                                 app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
     url = "%s/api/v1/accounts/%s" % (auth_url, account_id)
     response = requests.delete(url, headers=headers)
@@ -67,13 +67,13 @@ def delete_user(username,
 
 
 def get_account_id(username,
-                   access_token=None,
+                   token_manager=None,
                    app_url=defaults.APP_URL):
     """
     get the account id for the username specified
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
     url = "%s/api/v1/accounts?username=%s" % (auth_url, username)
 
@@ -87,13 +87,13 @@ def get_account_id(username,
         raise JutException('Error %s; %s' % (response.status_code, response.text))
 
 
-def get_logged_in_account_id(access_token=None,
+def get_logged_in_account_id(token_manager=None,
                              app_url=defaults.APP_URL):
     """
     get the account id for logged in account of the provided access_token
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
     url = "%s/api/v1/account" % auth_url
 
@@ -109,13 +109,13 @@ def get_logged_in_account_id(access_token=None,
 
 
 def user_exists(username,
-                access_token=None,
+                token_manager=None,
                 app_url=defaults.APP_URL):
     """
     check if the user exists with the specified username
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
     url = "%s/api/v1/accounts?username=%s" % (auth_url, username)
     response = requests.get(url, headers=headers)
@@ -129,13 +129,13 @@ def user_exists(username,
 
 
 def get_accounts(account_ids,
-                 access_token=None,
+                 token_manager=None,
                  app_url=defaults.APP_URL):
     """
     get the account details for each of the account ids in the account_ids list
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     auth_url = environment.get_auth_url(app_url=app_url)
 
     url = "%s/api/v1/accounts/%s" % (auth_url, ','.join(account_ids))

--- a/jut/api/authorizations.py
+++ b/jut/api/authorizations.py
@@ -6,23 +6,21 @@ jut authorizations API
 import requests
 
 from jut import defaults
-from jut.api import auth, environment
+from jut.api import environment
 from jut.exceptions import JutException
 
 
-def get_authorization(access_token,
+def get_authorization(token_manager,
                       app_url=defaults.APP_URL):
     """
     returns the authorization grant composed of the tuple client_id and
     client_secret provided with a valid access token
 
-    access_token: valid access toke obtained using auth.get_access_token
-    app_url: optional argument used primarily for internal Jut testing
     """
     auth_url = environment.get_auth_url(app_url=app_url)
     url = '%s/api/v1/authorizations' % auth_url
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     response = requests.post(url,
                              headers=headers)
 

--- a/jut/api/deployments.py
+++ b/jut/api/deployments.py
@@ -7,19 +7,20 @@ import json
 import requests
 
 from jut import defaults
+
+from jut.api import accounts, environment
 from jut.exceptions import JutException
-from jut.api import auth, accounts, environment
 
 ## deployments
 
-def get_deployments(access_token=None,
+def get_deployments(token_manager=None,
                     app_url=defaults.APP_URL):
     """
     return the list of deployments that the current access_token gives you
     access to
 
     """
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments' % deployment_url,
                             headers=headers)
@@ -31,14 +32,14 @@ def get_deployments(access_token=None,
 
 
 def get_deployment_id(deployment_name,
-                      access_token=None,
+                      token_manager=None,
                       app_url=defaults.APP_URL):
     """
     return the deployment id for the deployment with the specified name
 
     """
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments' % deployment_url,
                             headers=headers)
@@ -56,7 +57,7 @@ def get_deployment_id(deployment_name,
 
 
 def get_deployment_details(deployment_name,
-                           access_token=None,
+                           token_manager=None,
                            app_url=defaults.APP_URL):
     """
     return the deployment details for the deployment with the specific name
@@ -64,10 +65,10 @@ def get_deployment_details(deployment_name,
     """
 
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments/%s' %
                             (deployment_url, deployment_id),
@@ -80,13 +81,13 @@ def get_deployment_details(deployment_name,
 
 
 def get_apikey(deployment_name,
-               access_token=None,
+               token_manager=None,
                app_url=defaults.APP_URL):
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments/%s/apikey' %
                             (deployment_url, deployment_id),
@@ -101,17 +102,17 @@ def get_apikey(deployment_name,
 # spaces
 
 def get_spaces(deployment_name,
-               access_token=None,
+               token_manager=None,
                app_url=defaults.APP_URL):
     """
     get the list of spaces currently in the deployment specified
 
     """
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments/%s/spaces' %
                             (deployment_url, deployment_id),
@@ -125,14 +126,14 @@ def get_spaces(deployment_name,
 
 def get_space_id(deployment_name,
                  space_name,
-                 access_token=None,
+                 token_manager=None,
                  app_url=defaults.APP_URL):
     """
     get the space id that relates to the space name provided
 
     """
     spaces = get_spaces(deployment_name,
-                        access_token=access_token,
+                        token_manager=token_manager,
                         app_url=app_url)
 
     for space in spaces:
@@ -148,7 +149,7 @@ def create_space(deployment_name,
                  security_policy='public',
                  events_retention_days=0,
                  metrics_retention_days=0,
-                 access_token=None,
+                 token_manager=None,
                  app_url=defaults.APP_URL):
     """
     create a space within the deployment specified and with the various
@@ -156,7 +157,7 @@ def create_space(deployment_name,
 
     """
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
     payload = {
@@ -166,7 +167,7 @@ def create_space(deployment_name,
         'metrics_retention_days': metrics_retention_days,
     }
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.post('%s/api/v1/deployments/%s/spaces' %
                              (deployment_url, deployment_id),
@@ -181,19 +182,19 @@ def create_space(deployment_name,
 
 def delete_space(deployment_name,
                  space_name,
-                 access_token=None,
+                 token_manager=None,
                  app_url=defaults.APP_URL):
 
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
     space_id = get_space_id(deployment_name,
                             space_name,
-                            access_token=access_token,
+                            token_manager=token_manager,
                             app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.delete('%s/api/v1/deployments/%s/spaces/%s' %
                                (deployment_url, deployment_id, space_id),
@@ -207,11 +208,11 @@ def delete_space(deployment_name,
 
 def space_exists(deployment_name,
                  space_name,
-                 access_token=None,
+                 token_manager=None,
                  app_url=defaults.APP_URL):
 
     spaces = get_spaces(deployment_name,
-                        access_token=access_token,
+                        token_manager=token_manager,
                         app_url=app_url)
 
     for space in spaces:
@@ -224,17 +225,17 @@ def space_exists(deployment_name,
 # users
 
 def get_users(deployment_name,
-              access_token=None,
+              token_manager=None,
               app_url=defaults.APP_URL):
     """
     get all users in the deployment specified
 
     """
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.get('%s/api/v1/deployments/%s/accounts' %
                             (deployment_url, deployment_id),
@@ -248,21 +249,21 @@ def get_users(deployment_name,
 
 def add_user(username,
              deployment_name,
-             access_token=None,
+             token_manager=None,
              app_url=defaults.APP_URL):
     """
     add user to deployment
 
     """
     deployment_id = get_deployment_id(deployment_name,
-                                      access_token=access_token,
+                                      token_manager=token_manager,
                                       app_url=app_url)
 
     account_id = accounts.get_account_id(username,
-                                         access_token=access_token,
+                                         token_manager=token_manager,
                                          app_url=app_url)
 
-    headers = auth.access_token_to_headers(access_token)
+    headers = token_manager.get_access_token_headers()
     deployment_url = environment.get_deployment_url(app_url=app_url)
     response = requests.put('%s/api/v1/deployments/%s/accounts/%s' %
                             (deployment_url, deployment_id, account_id),

--- a/jut/api/integrations.py
+++ b/jut/api/integrations.py
@@ -11,19 +11,20 @@ from jut.api import deployments, data_engine
 def get_webhook_url(deployment_name,
                     space='default',
                     data_source='webhook',
-                    access_token=None,
+                    token_manager=None,
                     app_url=defaults.APP_URL,
                     **fields):
     """
+    return the webhook URL for posting webhook data to
 
     """
 
     import_url = data_engine.get_import_data_url(deployment_name,
                                                  app_url=app_url,
-                                                 access_token=access_token)
+                                                 token_manager=token_manager)
 
     api_key = deployments.get_apikey(deployment_name,
-                                     access_token=access_token,
+                                     token_manager=token_manager,
                                      app_url=app_url)
 
     fields_string = '&'.join(['%s=%s' % (key, value)

--- a/jut/cli.py
+++ b/jut/cli.py
@@ -133,6 +133,42 @@ def main():
                           default=False,
                           help='kill without prompting for confirmation')
 
+    connect_job = jobs_commands.add_parser('connect',
+                                           help='connect to a persistent job')
+
+    connect_job.add_argument('job_id',
+                             help='specify the job_id to connect to')
+
+    connect_job.add_argument('-d', '--deployment',
+                             default=None,
+                             help='specify the deployment name')
+
+    connect_job.add_argument('-a', '--app-url',
+                             default=defaults.APP_URL,
+                             help='app url (default: https://app.jut.io INTERNAL USE)')
+
+    connect_job.add_argument('-s', '--show-progress',
+                             action='store_true',
+                             default=False,
+                             help='writes the progress out to stderr on how '
+                                  'many points were streamed thus far')
+
+    connect_job.add_argument('--retry',
+                             type=int,
+                             default=0,
+                             help='retry running the program N times,'
+                                  'default 0. Use -1 to retry forever.')
+
+    connect_job.add_argument('--retry-delay',
+                             type=int,
+                             default=10,
+                             help='number of seconds to wait between retries.')
+
+    connect_job.add_argument('-f', '--format',
+                             default='json',
+                             help='available formats are json, text, csv with '
+                                  'default: json')
+
     # upload commands
     upload_parser = commands.add_parser('upload',
                                         help='upload local JSON file(s) to Jut')
@@ -223,6 +259,7 @@ def main():
 
     run_parser.add_argument('-p', '--persist',
                             action='store_true',
+                            default=False,
                             help='allow the program containing background '
                                  'outputs to become a persistent job by '
                                  'disconnecting form the running job (ie '
@@ -233,6 +270,17 @@ def main():
                             default=False,
                             help='writes the progress out to stderr on how '
                                  'many points were streamed thus far')
+
+    run_parser.add_argument('--retry',
+                            type=int,
+                            default=0,
+                            help='retry running the program N times,'
+                                 'default 0. Use -1 to retry forever.')
+
+    run_parser.add_argument('--retry-delay',
+                            type=int,
+                            default=10,
+                            help='number of seconds to wait between retries.')
 
     options = parser.parse_args()
 
@@ -256,6 +304,9 @@ def main():
 
             elif options.jobs_subcommand == 'kill':
                 jobs.kill(options)
+            
+            elif options.jobs_subcommand == 'connect':
+                jobs.connect(options)
 
         elif options.subcommand == 'upload':
             upload.upload_file(options)

--- a/jut/commands/configs.py
+++ b/jut/commands/configs.py
@@ -3,8 +3,6 @@ jut config command
 
 """
 
-import sys
-
 from jut import config
 
 from jut.api import auth, authorizations, deployments
@@ -19,11 +17,11 @@ def default_deployment(app_url, client_id, client_secret):
     if app_url.strip() == '':
         app_url = 'https://app.jut.io'
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
-    user_deployments = deployments.get_deployments(access_token=access_token,
+    user_deployments = deployments.get_deployments(token_manager=token_manager,
                                                    app_url=app_url)
 
     if len(user_deployments) > 1:
@@ -85,11 +83,11 @@ def add_configuration(options):
     if config.exists(section):
         raise JutException('Configuration for "%s" already exists' % section)
 
-    access_token = auth.get_access_token(username=username,
-                                         password=password,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(username=username,
+                                      password=password,
+                                      app_url=app_url)
 
-    client_id, client_secret = authorizations.get_authorization(access_token,
+    client_id, client_secret = authorizations.get_authorization(token_manager,
                                                                 app_url=app_url)
 
     deployment_name = default_deployment(app_url,

--- a/jut/commands/jobs.py
+++ b/jut/commands/jobs.py
@@ -4,6 +4,7 @@ jut config command
 """
 
 import tabulate
+import time
 
 from collections import OrderedDict
 
@@ -11,12 +12,14 @@ from jut import config
 
 from jut.api import auth, accounts, data_engine
 from jut.common import info, error
+from jut.commands import configs
 from jut.exceptions import JutException
+from jut.formatters import JSONFormatter, TextFormatter, CSVFormatter
 
 from jut.util.console import prompt
 
 
-def _print_jobs(jobs, access_token, app_url, options):
+def _print_jobs(jobs, token_manager, app_url, options):
     """
     internal method to print the provided jobs array in a nice tabular
     format
@@ -35,7 +38,7 @@ def _print_jobs(jobs, access_token, app_url, options):
 
     if accountids:
         accounts_details = accounts.get_accounts(accountids,
-                                                 access_token=access_token,
+                                                 token_manager=token_manager,
                                                  app_url=app_url)
 
         for account in accounts_details['accounts']:
@@ -126,12 +129,12 @@ def list(options):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     jobs = data_engine.get_jobs(deployment_name,
-                                access_token=access_token,
+                                token_manager=token_manager,
                                 app_url=app_url)
 
 
@@ -139,7 +142,7 @@ def list(options):
         error('No running jobs')
 
     else:
-        _print_jobs(jobs, access_token, app_url, options)
+        _print_jobs(jobs, token_manager, app_url, options)
 
 
 def kill(options):
@@ -158,28 +161,165 @@ def kill(options):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     job_details = data_engine.get_job_details(options.job_id,
                                               deployment_name,
-                                              access_token=access_token,
+                                              token_manager=token_manager,
                                               app_url=app_url)
 
-    options.format='table'
+    options.format = 'table'
 
     if options.yes:
         decision = 'Y'
     else:
-        _print_jobs([job_details], access_token, app_url, options)
+        _print_jobs([job_details], token_manager, app_url, options)
         decision = prompt('Are you sure you want to delete the above job? (Y/N)')
 
     if decision == 'Y':
         data_engine.delete_job(options.job_id.strip(),
                                deployment_name,
-                               access_token=access_token,
+                               token_manager=token_manager,
                                app_url=app_url)
 
     else:
         raise JutException('Unexpected option "%s"' % decision)
+
+
+def connect(options):
+    options.persist = False
+
+    if not config.is_configured():
+        configs.add_configuration(options)
+
+    configuration = config.get_default()
+    app_url = configuration['app_url']
+
+    if options.deployment != None:
+        deployment_name = options.deployment
+    else:
+        deployment_name = configuration['deployment_name']
+
+    client_id = configuration['client_id']
+    client_secret = configuration['client_secret']
+
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
+
+    total_points = 0
+
+    def show_progress():
+        if options.show_progress:
+            error('streamed %s points', total_points, end='\r')
+
+    def show_error_or_warning(data):
+        """
+        handle error and warning reporting
+
+        """
+        if 'error' in data:
+            prefix = 'Error'
+
+        elif 'warning' in data:
+            prefix = 'Warning'
+
+        else:
+            raise Exception('Unexpected error/warning received %s' % data)
+
+        message = None
+        location = None
+
+        if 'context' in data:
+            message = data['context']['message']
+
+            # not all errors or warnings have location information
+            if 'location' in data['context']['info']:
+                location = data['context']['info']['location']
+                line = location['start']['line']
+                column = location['start']['column']
+
+        else:
+            message = '%s: %s' % (prefix, message)
+
+        if location != None:
+            error('%s line %s, column %s of %s: %s' %
+                  (prefix, line, column, location['filename'], message))
+
+        else:
+            error(message)
+
+    if options.format == 'json':
+        formatter = JSONFormatter(options)
+
+    elif options.format == 'text':
+        formatter = TextFormatter(options)
+
+    elif options.format == 'csv':
+        formatter = CSVFormatter(options)
+
+    else:
+        raise JutException('Unsupported output format "%s"' %
+                           options.format)
+
+    job_id = options.job_id
+
+    done = False
+    with_errors = False
+    max_retries = options.retry
+    retry_delay = options.retry_delay
+    retry = 0
+
+    while not done:
+        try:
+            if not options.persist:
+                formatter.start()
+
+            for data in data_engine.connect_job(job_id,
+                                                deployment_name,
+                                                token_manager=token_manager,
+                                                app_url=app_url):
+                show_progress()
+
+                if 'job' in data:
+                    # job details
+                    if options.persist:
+                        # lets print the job id
+                        info(data['job']['id'])
+
+                if 'points' in data:
+                    points = data['points']
+                    for point in points:
+                        formatter.point(point)
+
+                    total_points += len(points)
+
+                elif 'error' in data:
+                    show_error_or_warning(data)
+                    with_errors = True
+
+                elif 'warning' in data:
+                    show_error_or_warning(data)
+
+            done = True
+
+        except JutException:
+            retry += 1
+
+            if max_retries != -1 and retry > max_retries:
+                raise
+
+            time.sleep(retry_delay)
+
+        finally:
+            if options.show_progress:
+                # one enter to retain the last value of progress output
+                info('')
+
+            if not options.persist:
+                formatter.stop()
+
+            if with_errors:
+                raise JutException('Error while running juttle')

--- a/jut/commands/upload.py
+++ b/jut/commands/upload.py
@@ -7,8 +7,9 @@ import json
 import requests
 import sys
 
-from jut.api import auth, integrations
 from jut import config
+
+from jut.api import auth, integrations
 from jut.common import info
 
 
@@ -113,13 +114,13 @@ def upload_file(options):
         client_id = configuration['client_id']
         client_secret = configuration['client_secret']
 
-        access_token = auth.get_access_token(client_id=client_id,
-                                             client_secret=client_secret,
-                                             app_url=app_url)
+        token_manager = auth.TokenManager(client_id=client_id,
+                                          client_secret=client_secret,
+                                          app_url=app_url)
 
         url = integrations.get_webhook_url(deployment_name,
                                            space=options.space,
-                                           access_token=access_token,
+                                           token_manager=token_manager,
                                            app_url=app_url)
 
     info('Pushing to %s' % url)

--- a/jut/formatters.py
+++ b/jut/formatters.py
@@ -45,12 +45,12 @@ class JSONFormatter(Formatter):
     def point(self, point):
         if self.previous_point:
             info(',')
-        info(json.dumps(point, indent=4))
+        info(json.dumps(point, indent=2), end='')
         self.previous_point = True
 
     def stop(self):
         if not self.options.persist:
-            info(']')
+            info('\n]')
 
 class TextFormatter(Formatter):
 

--- a/tests/jut_upload_tests.py
+++ b/tests/jut_upload_tests.py
@@ -51,9 +51,7 @@ class JutUploadTests(unittest.TestCase):
                       '--url', webhook_url,
                       '--space', JutUploadTests.test_space,
                       stdin=None)
-
-        status = process.wait()
-        self.assertEquals(status, 0)
+        process.expect_status(0)
 
         # read a few times till all the points appear as it takes a few seconds
         # before the data is committed permanently
@@ -64,15 +62,13 @@ class JutUploadTests(unittest.TestCase):
 
         while len(points) < 10 and retry < 10:
             process = jut('run', juttle)
-            status = process.wait()
-            self.assertEquals(status, 0)
+            process.expect_status(0)
             points = json.loads(process.read_output())
             process.expect_eof()
             retry += 1
 
         process = jut('run', '%s | reduce count()' % juttle)
-        status = process.wait()
-        self.assertEquals(status, 0)
+        process.expect_status(0)
         points = json.loads(process.read_output())
         process.expect_eof()
 
@@ -100,8 +96,7 @@ class JutUploadTests(unittest.TestCase):
                       '--space', JutUploadTests.test_space,
                       stdin=None)
 
-        status = process.wait()
-        self.assertEquals(status, 0)
+        process.expect_status(0)
 
         # read a few times till all the points appear as it takes a few seconds
         # before the data is committed permanently
@@ -112,15 +107,13 @@ class JutUploadTests(unittest.TestCase):
 
         while len(points) < 10 and retry < 10:
             process = jut('run', juttle)
-            status = process.wait()
-            self.assertEquals(status, 0)
+            process.expect_status(0)
             points = json.loads(process.read_output())
             process.expect_eof()
             retry += 1
 
         process = jut('run', '%s | reduce count()' % juttle)
-        status = process.wait()
-        self.assertEquals(status, 0)
+        process.expect_status(0)
         points = json.loads(process.read_output())
         process.expect_eof()
         self.assertEqual(points, [{'count': 10}])

--- a/tests/util.py
+++ b/tests/util.py
@@ -184,7 +184,13 @@ class Spawn(object):
         """
         return self.process.wait()
 
+
     def expect_status(self, expected_status):
+        """
+        expect the provided status exit code otherwise output the full stdout
+        and stderr output at that specific point in time
+
+        """
         status = self.wait()
 
         if status != expected_status:
@@ -192,6 +198,14 @@ class Spawn(object):
             error(self.read_error())
             raise Exception('Expected status %s, got %s' % (expected_status, status))
 
+
+    def send_signal(self, signal_name):
+        """
+        send the signal provided to the currently running process
+
+        """
+
+        self.process.send_signal(signal_name)
 
 def jut(*args,
         **kwargs):
@@ -223,9 +237,9 @@ def create_user_in_default_deployment(name, username, email, password):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     delete_user_from_default_deployment(username, password)
 
@@ -233,12 +247,12 @@ def create_user_in_default_deployment(name, username, email, password):
                          username,
                          email,
                          password,
-                         access_token=access_token,
+                         token_manager=token_manager,
                          app_url=app_url)
 
     deployments.add_user(username,
                          deployment_name,
-                         access_token=access_token,
+                         token_manager=token_manager,
                          app_url=app_url)
 
 
@@ -251,20 +265,20 @@ def delete_user_from_default_deployment(username, password):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     if accounts.user_exists(username,
-                            access_token=access_token,
+                            token_manager=token_manager,
                             app_url=app_url):
 
-        delete_access_token = auth.get_access_token(username=username,
-                                                    password=password,
-                                                    app_url=app_url)
+        delete_token_manager = auth.TokenManager(username=username,
+                                                 password=password,
+                                                 app_url=app_url)
 
         accounts.delete_user(username,
-                             access_token=delete_access_token,
+                             token_manager=delete_token_manager,
                              app_url=app_url)
 
 
@@ -280,16 +294,16 @@ def get_webhook_url(space):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     import_url = data_engine.get_import_data_url(deployment_name,
-                                                 access_token=access_token,
+                                                 token_manager=token_manager,
                                                  app_url=app_url)
 
     api_key = deployments.get_apikey(deployment_name,
-                                     access_token=access_token,
+                                     token_manager=token_manager,
                                      app_url=app_url)
 
     return '%s/api/v1/import/webhook/?space=%s&data_source=webhook&apikey=%s' % \
@@ -304,19 +318,19 @@ def create_space_in_default_deployment(space_name):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     if deployments.space_exists(deployment_name,
                                 space_name,
-                                access_token=access_token,
+                                token_manager=token_manager,
                                 app_url=app_url):
         delete_space_from_default_deployment(space_name)
 
     deployments.create_space(deployment_name,
                              space_name,
-                             access_token=access_token,
+                             token_manager=token_manager,
                              app_url=app_url)
 
     time.sleep(SPACE_CREATE_TIMEOUT)
@@ -330,13 +344,13 @@ def delete_space_from_default_deployment(space_name):
     client_id = configuration['client_id']
     client_secret = configuration['client_secret']
 
-    access_token = auth.get_access_token(client_id=client_id,
-                                         client_secret=client_secret,
-                                         app_url=app_url)
+    token_manager = auth.TokenManager(client_id=client_id,
+                                      client_secret=client_secret,
+                                      app_url=app_url)
 
     deployments.delete_space(deployment_name,
                              space_name,
-                             access_token=access_token,
+                             token_manager=token_manager,
                              app_url=app_url)
 
 


### PR DESCRIPTION
added a new TokenManager to handle the refresh of access token's at
runtime and while doing that we can now correctly refresh tokens every
hour during `jut run` executions which allows the juttle program to run
for hours on end. Also added new reconnect feature to the run juttle api
so that we can even tolerate some network glitches.